### PR TITLE
Cleanup ProcessExtensions.

### DIFF
--- a/NetUtilities/System/Diagnostics/ProcessExtensions.cs
+++ b/NetUtilities/System/Diagnostics/ProcessExtensions.cs
@@ -77,8 +77,8 @@ namespace System.Diagnostics
             options.Executing = false;
             
             // cleanup the code here.
-            var ret = process.StartInfo.RedirectStandardError ? process.StandardError.ReadToEnd() : string.Empty;
-            ret += process.StartInfo.RedirectStandardOutput ? process.StandardOutput.ReadToEnd() : string.Empty;
+            var ret = process.StartInfo.RedirectStandardOutput ? process.StandardOutput.ReadToEnd() : string.Empty;
+            ret += process.StartInfo.RedirectStandardError ? process.StandardError.ReadToEnd() : string.Empty;
             if (options.WaitForProcessExit)
                 process.WaitForExit();
 

--- a/NetUtilities/System/Diagnostics/ProcessExtensions.cs
+++ b/NetUtilities/System/Diagnostics/ProcessExtensions.cs
@@ -73,17 +73,12 @@ namespace System.Diagnostics
         /// </returns>
         public static string Shell(this Process process, ProcessOptions options)
         {
-            var ret = string.Empty;
-
             process.Start();
             options.Executing = false;
-
-            if (process.StartInfo.RedirectStandardError)
-                ret = process.StandardError.ReadToEnd();
-
-            if (process.StartInfo.RedirectStandardOutput)
-                ret = process.StandardOutput.ReadToEnd();
-
+            
+            // cleanup the code here.
+            var ret = process.StartInfo.RedirectStandardError ? process.StandardError.ReadToEnd() : string.Empty;
+            ret += process.StartInfo.RedirectStandardOutput ? process.StandardOutput.ReadToEnd() : string.Empty;
             if (options.WaitForProcessExit)
                 process.WaitForExit();
 

--- a/NetUtilities/System/Diagnostics/ProcessExtensions.cs
+++ b/NetUtilities/System/Diagnostics/ProcessExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text;
 
 namespace System.Diagnostics
 {
@@ -73,16 +74,21 @@ namespace System.Diagnostics
         /// </returns>
         public static string Shell(this Process process, ProcessOptions options)
         {
+            var ret = new StringBuilder();
             process.Start();
             options.Executing = false;
-            
+
             // cleanup the code here.
-            var ret = process.StartInfo.RedirectStandardOutput ? process.StandardOutput.ReadToEnd() : string.Empty;
-            ret += process.StartInfo.RedirectStandardError ? process.StandardError.ReadToEnd() : string.Empty;
+            if (process.StartInfo.RedirectStandardOutput)
+                ret.Append(process.StandardOutput.ReadToEnd());
+
+            if (process.StartInfo.RedirectStandardError)
+                ret.Append(process.StandardError.ReadToEnd());
+
             if (options.WaitForProcessExit)
                 process.WaitForExit();
 
-            return ret;
+            return ret.ToString();
         }
     }
 }


### PR DESCRIPTION
This cleans up the ProcessExtensions on the checks that write to the output string variable, this makes it more readable and less lines of code.

Also doing it like this avoids wiping out one value when you enable to set both standard output AND error redirections.